### PR TITLE
Allow .xml suffix and set correct Content-Type header

### DIFF
--- a/pages/api/docsets.js
+++ b/pages/api/docsets.js
@@ -1,4 +1,5 @@
 import { getDocsets } from "../../src/utils";
 export default (req, res) => {
+  res.setHeader("Content-Type", "application/xml");
   getDocsets().then((d) => res.status(200).json(d));
 };

--- a/pages/api/docsets.js
+++ b/pages/api/docsets.js
@@ -1,5 +1,4 @@
 import { getDocsets } from "../../src/utils";
 export default (req, res) => {
-  res.setHeader("Content-Type", "application/xml");
   getDocsets().then((d) => res.status(200).json(d));
 };

--- a/pages/api/docsets/[name].js
+++ b/pages/api/docsets/[name].js
@@ -7,6 +7,7 @@ export default (req, res) => {
 
   getDocsets(name)
     .then((list) => {
+      res.setHeader("Content-Type", "application/xml");
       res.send(xmlify(list));
     })
     .catch((err) => {

--- a/pages/api/docsets/[name].js
+++ b/pages/api/docsets/[name].js
@@ -5,7 +5,10 @@ export default (req, res) => {
     query: { name },
   } = req;
 
-  getDocsets(name)
+  // Zeal <= 0.6.1 assumes all feed urls have a .xml suffix
+  const trimmedName = name.endsWith('.xml') ? name.substr(0, name.length - 4) : name;
+
+  getDocsets(trimmedName)
     .then((list) => {
       res.setHeader("Content-Type", "application/xml");
       res.send(xmlify(list));

--- a/pages/api/feed.js
+++ b/pages/api/feed.js
@@ -2,7 +2,7 @@ import { getDocsets, xmlify } from "../../src/utils";
 
 export default (req, res) => {
   getDocsets().then((list) => {
-    // res.set("Content-Type", "text/xml");
+    res.setHeader("Content-Type", "application/xml");
     res.status(200).send(xmlify(list));
     // xmlify(list)
   });


### PR DESCRIPTION
This PR adds a fix for https://github.com/zealdocs/zeal/issues/1240 to this repository. In the current Zeal release all feed urls are assumed to have a `.xml` suffix, which this PR adds support for. Although it is nice that this assumption in Zeal will go away in the 0.7.0 release, at the moment it is impossible to use this project with the latest release of Zeal.

Besides that this PR sets the correct `Content-Type` header on API responses which return XML, so that browsers print the XML in a nicer way when manually going to any of those API endpoints.